### PR TITLE
Add Close() to the Source interface

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -35,6 +35,11 @@ func exportCommand(cmd *cobra.Command, args []string, f func(s source.Source, it
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err := s.Close(); err != nil {
+			logger.WithError(err).Fatal("Failed to clean up")
+		}
+	}()
 
 	for {
 		item, err := iter.Next()

--- a/pkg/source/chirpstack/source.go
+++ b/pkg/source/chirpstack/source.go
@@ -382,3 +382,8 @@ func (p *Source) ExportDevice(devEui string) (*ttnpb.EndDevice, error) {
 
 	return dev, nil
 }
+
+// Close implements the Source interface.
+func (p *Source) Close() error {
+	return p.cc.Close()
+}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -30,6 +30,8 @@ type Source interface {
 	ExportDevice(devID string) (*ttnpb.EndDevice, error)
 	// RangeDevices calls a function for all matching devices of an application.
 	RangeDevices(appID string, f func(s Source, devID string) error) error
+	// Close cleans up and terminates any open connections.
+	Close() error
 }
 
 // CreateSource is a function that constructs a new Source.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #9 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a `Close() error` method to the `Source` interface, which can clean up and terminate any open connections.
- Call `Close()` after exporting devices.

#### Testing

<!-- How did you verify that this change works? -->

- Test locally
