### PR TITLE
fix: Properly export TTNv2 devices without an active session

### DIFF
--- a/pkg/source/ttnv2/source.go
+++ b/pkg/source/ttnv2/source.go
@@ -144,7 +144,7 @@ func (s *Source) ExportDevice(devID string) (*ttnpb.EndDevice, error) {
 		}
 	}
 
-	if s.config.withSession && dev.DevAddr != nil && dev.NwkSKey != nil && dev.AppSKey != nil {
+	if s.config.withSession && dev.DevAddr != nil && !dev.DevAddr.IsEmpty() && dev.NwkSKey != nil && !dev.NwkSKey.IsEmpty() && dev.AppSKey != nil && !dev.AppSKey.IsEmpty() {
 		v3dev.Session = &ttnpb.Session{
 			SessionKeys: ttnpb.SessionKeys{
 				AppSKey: &ttnpb.KeyEnvelope{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Quickfix PR, fixes devices exported from TTNv2 without an active session having all zeros `DevAddr`, `AppSKey`, `NwkSKey`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Check that `IsEmpty()` is false for session keys in order to export the session.

#### Testing

<!-- How did you verify that this change works? -->

Previously, devices without an active session would be exported with `{...., "session": {"dev_addr": "00000000", ....}`.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Exporting devices with an active session is not affected.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
