### PR TITLE
Fail if exported devices contain invalid fields

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,7 @@ var (
 		Use:   "ttn-lw-migrate",
 		Short: "Migrate from other LoRaWAN network servers to The Things Stack",
 
+		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			logLevel := log.InfoLevel
 			if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Validate exported devices exported, and fail if any fields are invalid.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `ttnpb.EndDevice.ValidateFields` to validate that the exported device does not contain any errors
- Fail if validation fails
- Take this chance to replace `_` occurences with `-`, since `_` was an allowed character in TTN V2.

#### Testing

<!-- How did you verify that this change works? -->

Export a device with name `some_device`.

- Without this change: No errors, device exported with invalid id, importing to TTS fails.
- With this change: Device exported as `some-device` instead, and all fields validated.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
