### PR TITLE
Send all log messages to stderr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/TheThingsNetwork/go-app-sdk v0.0.0-20191121100818-5bae20ae2b27
 	github.com/TheThingsNetwork/go-utils v0.0.0-20190516083235-bdd4967fab4e
 	github.com/TheThingsNetwork/ttn/utils/errors v0.0.0-20190516081709-034d40b328bd
+	github.com/apex/log v1.1.0
 	github.com/aws/aws-sdk-go v1.34.9 // indirect
 	github.com/brocaar/chirpstack-api/go/v3 v3.7.5
 	github.com/envoyproxy/protoc-gen-validate v0.4.1 // indirect

--- a/pkg/source/ttnv2/config.go
+++ b/pkg/source/ttnv2/config.go
@@ -22,8 +22,10 @@ import (
 	"os"
 
 	ttnsdk "github.com/TheThingsNetwork/go-app-sdk"
+	"github.com/TheThingsNetwork/go-utils/handlers/cli"
 	ttnlog "github.com/TheThingsNetwork/go-utils/log"
-	"github.com/TheThingsNetwork/go-utils/log/apex"
+	ttnapex "github.com/TheThingsNetwork/go-utils/log/apex"
+	apex "github.com/apex/log"
 	"github.com/spf13/pflag"
 )
 
@@ -117,10 +119,14 @@ func getConfig(ctx context.Context, flags *pflag.FlagSet) (config, error) {
 		return config{}, errNoFrequencyPlanID.New()
 	}
 
-	logger := apex.Stdout()
+	logLevel := ttnapex.InfoLevel
 	if boolFlag("verbose") {
-		logger.MustParseLevel("debug")
+		logLevel = ttnapex.DebugLevel
 	}
+	logger := ttnapex.Wrap(&apex.Logger{
+		Level:   logLevel,
+		Handler: cli.New(os.Stderr),
+	})
 	ttnlog.Set(logger)
 
 	return config{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Log all messages from TTNv2 SDK client to stderr instead of stdout.

#### Changes
<!-- What are the changes made in this pull request? -->

- Replace `apex.Stdout()` with an identical logger that writes to `os.Stderr` instead

#### Testing

<!-- How did you verify that this change works? -->

Without change, TTNv2 client logs are written to stdout, breaking the list of exported devices.
With change, all logs are written to stderr instead.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
