### PR TITLE
Configure factory preset frequencies for TTNv2 ABP devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- `--ttnv2.resets-to-frequency-plan` flag for configuring factory preset frequencies when exporting ABP devices from The Things Network Stack V2. The list of frequencies is inferred from the chosen Frequency Plan.
+
 ### Changed
 
 - Upgrade The Things Stack API to version `3.13.0`.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ $ export TTNV2_DISCOVERY_SERVER_ADDRESS="discovery.thethings.network:1900"
 - The export process will halt if any error occurs.
 - Execute commands with the `--dry-run` flag to verify whether the outcome will be as expected.
 - Payload formatters are not exported. See [Payload Formatters](https://thethingsstack.io/integrations/payload-formatters/).
+- For ABP devices, use the `--ttnv2.resets-to-frequency-plan` flag to configure the factory preset frequencies of the device, so that it can keep working with The Things Stack. The list of uplink frequencies is inferred from the Frequency Plan.
 - Device sessions (**AppSKey**, **NwkSKey**, **DevAddr**, **FCntUp** and **FCntDown**) are exported by default. You can disable this by using the `--ttnv2.with-session=false` flag. It is recommended that you do not export session keys for devices that can instead re-join on The Things Stack.
 - **IMPORTANT**: The migration from The Things Network Stack V2 to The Things Stack is one-way. Note that it is crucial that devices are handled by one Network Server at a time. The commands below will clear both the root keys (**AppKey**, if any) and the session (**AppSKey**, **NwkSKey** and **DevAddr**) from The Things Network Stack V2 after exporting the devices. Make sure you understand the ramifications of this. **Note that having the session keys present on both Network Servers is not supported, and you will most likely encounter uplink/downlink traffic issues and/or a corrupted device MAC state**.
 

--- a/pkg/source/ttnv2/config.go
+++ b/pkg/source/ttnv2/config.go
@@ -42,8 +42,9 @@ type config struct {
 
 	frequencyPlanID string
 
-	withSession bool
-	dryRun      bool
+	withSession           bool
+	dryRun                bool
+	resetsToFrequencyPlan bool
 
 	fpStore *frequencyplans.Store
 }
@@ -61,6 +62,7 @@ func flagSet() *pflag.FlagSet {
 	flags.String("ttnv2.discovery-server-address", os.Getenv("TTNV2_DISCOVERY_SERVER_ADDRESS"), "(only for private networks) Address for the Discovery Server")
 	flags.Bool("ttnv2.discovery-server-insecure", false, "(only for private networks) Not recommended")
 	flags.Bool("ttnv2.with-session", true, "Export device session keys and frame counters")
+	flags.Bool("ttnv2.resets-to-frequency-plan", false, "Configure preset frequencies for ABP devices so that they match the used Frequency Plan")
 
 	return flags
 }
@@ -146,7 +148,8 @@ func getConfig(flags *pflag.FlagSet) (config, error) {
 		appAccessKey:    appAccessKey,
 		frequencyPlanID: frequencyPlanID,
 
-		withSession: boolFlag("ttnv2.with-session"),
+		withSession:           boolFlag("ttnv2.with-session"),
+		resetsToFrequencyPlan: boolFlag("ttnv2.resets-to-frequency-plan"),
 
 		dryRun:  boolFlag("dry-run"),
 		fpStore: frequencyplans.NewStore(fpFetcher),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Configure factory preset frequencies for ABP devices exported from TTN v2.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add new `--ttnv2.resets-to-frequency-plan` flag, disabled by default.
- When the flag is set, the `mac_settings.factory_preset_frequencies` is set for ABP devices, inferred from the uplink channel frequencies of the Frequency Plan.

#### Testing

<!-- How did you verify that this change works? -->

For an ABP device with `EU_863_870_TTN` frequency plan:

```
$ ttn-lw-migrate device abp --source ttnv2 --dry-run | jq '.mac_settings' -c
{"rx1_delay":{"value":1}}

$ ttn-lw-migrate device abp --source ttnv2 --dry-run --ttnv2.resets-to-frequency-plan | jq '.mac_settings' -c
{"rx1_delay":{"value":1},"factory_preset_frequencies":["868100000","868300000","868500000","867100000","867300000","867500000","867700000","867900000"]}
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@rvolosatovs Is this the correct way to set the `PresetFactoryFrequencies` field for ABP devices?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
