### PR TITLE
Retry Resource Exhausted errors with a backoff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/TheThingsNetwork/go-app-sdk v0.0.0-20191121100818-5bae20ae2b27
 	github.com/TheThingsNetwork/go-utils v0.0.0-20190516083235-bdd4967fab4e
 	github.com/TheThingsNetwork/ttn/core/types v0.0.0-20190516112328-fcd38e2b9dc6
-	github.com/TheThingsNetwork/ttn/utils/errors v0.0.0-20190516081709-034d40b328bd
 	github.com/apex/log v1.1.0
 	github.com/aws/aws-sdk-go v1.34.9 // indirect
 	github.com/brocaar/chirpstack-api/go/v3 v3.7.5

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,7 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
+github.com/golang/gddo v0.0.0-20200519224240-a4ebd2f7e574 h1:+9Xv0CGhGr/xqk28z0zpbtoNSKqECWkJ6MO8XNJOEMQ=
 github.com/golang/gddo v0.0.0-20200519224240-a4ebd2f7e574/go.mod h1:sam69Hju0uq+5uvLJUMDlsKlQ21Vrs1Kd/1YFPNYdOU=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -478,6 +479,7 @@ github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmK
 github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
+github.com/inconshreveable/log15 v0.0.0-20170622235902-74a0988b5f80 h1:g/SJtZVYc1cxSB8lgrgqeOlIdi4MhqNNHYRAC8y+g4c=
 github.com/inconshreveable/log15 v0.0.0-20170622235902-74a0988b5f80/go.mod h1:cOaXtrgN4ScfRrD9Bre7U1thNq5RtJ8ZoP4iXVGRj6o=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/pkg/source/ttnv2/retry.go
+++ b/pkg/source/ttnv2/retry.go
@@ -1,0 +1,73 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnv2
+
+import (
+	"context"
+	"time"
+
+	ttnsdk "github.com/TheThingsNetwork/go-app-sdk"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
+)
+
+// deviceManagerWithRetry is a ttnsdk.DeviceManager that retries Set() and Get() methods when a resource exhausted or service unavailable error is returned.
+type deviceManagerWithRetry struct {
+	ttnsdk.DeviceManager
+
+	ctx        context.Context
+	maxRetries uint
+	backoff    time.Duration
+}
+
+func (d *deviceManagerWithRetry) shouldRetry(err error, try uint, fields log.Fielder) (bool, time.Duration) {
+	if err == nil {
+		return false, 0
+	}
+	if err, ok := errors.From(err); ok && (errors.IsResourceExhausted(err) || errors.IsUnavailable(err)) && try < d.maxRetries {
+		penalty := d.backoff * time.Duration(try)
+		log.FromContext(d.ctx).WithError(err).WithField("try", try).WithFields(fields).Warnf("Non-fatal error, will retry after %v", penalty)
+		return true, penalty
+	}
+	return false, 0
+}
+
+func (d *deviceManagerWithRetry) get(devID string, try uint) (*ttnsdk.Device, error) {
+	dev, err := d.DeviceManager.Get(devID)
+	if retry, penalty := d.shouldRetry(err, try, log.Fields("device_id", devID, "method", "Set")); retry {
+		time.Sleep(penalty)
+		return d.get(devID, try+1)
+	}
+	return dev, err
+}
+
+func (d *deviceManagerWithRetry) set(dev *ttnsdk.Device, try uint) error {
+	err := d.DeviceManager.Set(dev)
+	if retry, penalty := d.shouldRetry(err, try, log.Fields("dev_eui", dev.DevEUI, "device_id", dev.DevID, "method", "Set")); retry {
+		time.Sleep(penalty)
+		return d.set(dev, try+1)
+	}
+	return err
+}
+
+func (d *deviceManagerWithRetry) Get(devID string) (*ttnsdk.Device, error) {
+	return d.get(devID, 1)
+}
+
+func (d *deviceManagerWithRetry) Set(dev *ttnsdk.Device) error {
+	return d.set(dev, 1)
+}
+
+var _ ttnsdk.DeviceManager = &deviceManagerWithRetry{}

--- a/pkg/source/ttnv2/retry.go
+++ b/pkg/source/ttnv2/retry.go
@@ -32,42 +32,50 @@ type deviceManagerWithRetry struct {
 	backoff    time.Duration
 }
 
-func (d *deviceManagerWithRetry) shouldRetry(err error, try uint, fields log.Fielder) (bool, time.Duration) {
-	if err == nil {
+func (d *deviceManagerWithRetry) shouldRetry(ctx context.Context, err error, attempt uint) (bool, time.Duration) {
+	if err == nil || attempt >= d.maxRetries {
 		return false, 0
 	}
-	if err, ok := errors.From(err); ok && (errors.IsResourceExhausted(err) || errors.IsUnavailable(err)) && try < d.maxRetries {
-		penalty := d.backoff * time.Duration(try)
-		log.FromContext(d.ctx).WithError(err).WithField("try", try).WithFields(fields).Warnf("Non-fatal error, will retry after %v", penalty)
+	if err, ok := errors.From(err); ok && (errors.IsResourceExhausted(err) || errors.IsUnavailable(err)) {
+		penalty := d.backoff * time.Duration(attempt)
+		log.FromContext(d.ctx).WithError(err).WithField("attempt", attempt).Debugf("Non-fatal error, will retry after %v", penalty)
 		return true, penalty
 	}
 	return false, 0
 }
 
-func (d *deviceManagerWithRetry) get(devID string, try uint) (*ttnsdk.Device, error) {
+func (d *deviceManagerWithRetry) get(ctx context.Context, devID string, attempt uint) (*ttnsdk.Device, error) {
 	dev, err := d.DeviceManager.Get(devID)
-	if retry, penalty := d.shouldRetry(err, try, log.Fields("device_id", devID, "method", "Set")); retry {
-		time.Sleep(penalty)
-		return d.get(devID, try+1)
+	if retry, penalty := d.shouldRetry(ctx, err, attempt); retry {
+		select {
+		case <-time.After(penalty):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return d.get(ctx, devID, attempt+1)
 	}
 	return dev, err
 }
 
-func (d *deviceManagerWithRetry) set(dev *ttnsdk.Device, try uint) error {
+func (d *deviceManagerWithRetry) set(ctx context.Context, dev *ttnsdk.Device, attempt uint) error {
 	err := d.DeviceManager.Set(dev)
-	if retry, penalty := d.shouldRetry(err, try, log.Fields("dev_eui", dev.DevEUI, "device_id", dev.DevID, "method", "Set")); retry {
-		time.Sleep(penalty)
-		return d.set(dev, try+1)
+	if retry, penalty := d.shouldRetry(ctx, err, attempt); retry {
+		select {
+		case <-time.After(penalty):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		return d.set(ctx, dev, attempt+1)
 	}
 	return err
 }
 
 func (d *deviceManagerWithRetry) Get(devID string) (*ttnsdk.Device, error) {
-	return d.get(devID, 1)
+	return d.get(log.NewContextWithFields(d.ctx, log.Fields("device_id", devID, "method", "Get")), devID, 1)
 }
 
 func (d *deviceManagerWithRetry) Set(dev *ttnsdk.Device) error {
-	return d.set(dev, 1)
+	return d.set(log.NewContextWithFields(d.ctx, log.Fields("dev_eui", dev.DevEUI, "device_id", dev.DevID, "method", "Set")), dev, 1)
 }
 
 var _ ttnsdk.DeviceManager = &deviceManagerWithRetry{}

--- a/pkg/source/ttnv2/source.go
+++ b/pkg/source/ttnv2/source.go
@@ -31,9 +31,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 )
 
-// backoff to use before next try when client receives an error of type ResourceExhausted.
-const backoff = time.Second
-
 // Source implements the Source interface.
 type Source struct {
 	ctx context.Context
@@ -55,11 +52,11 @@ func NewSource(ctx context.Context, flags *pflag.FlagSet) (source.Source, error)
 		config: config,
 		client: config.sdkConfig.NewClient(config.appID, config.appAccessKey),
 	}
-	s.mgr, err = s.client.ManageDevices()
+	mgr, err := s.client.ManageDevices()
 	if err != nil {
 		return nil, err
 	}
-	s.mgr = &deviceManagerWithRetry{s.mgr, ctx, 15, backoff}
+	s.mgr = newDeviceManager(ctx, mgr)
 	return s, nil
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

When receiving errors of type Resource Exhausted or Unavailable from the TTNv2 server, retry call with a linear backoff.

#### Changes
<!-- What are the changes made in this pull request? -->

- Wrap `ttnsdk.DeviceManager` in `deviceManagerWithRetry`, which handles retry-able errors with a linear backoff

#### Testing

<!-- How did you verify that this change works? -->

Integration testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
