### PR TITLE
Add compatibility note with TTS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Migrate devices from other LoRaWAN Network Servers to [The Things Stack](https://thethingsstack.io).
 
+**IMPORTANT**: `ttn-lw-migrate` is compatible with The Things Stack versions **3.12.0** or newer. Trying to import the devices into earlier versions of The Things Stack will fail, due to breaking API changes.
+
 ## Installation
 
 Binaries are available on [GitHub](https://github.com/TheThingsNetwork/lorawan-stack-migrate/releases).


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Add a note that `ttn-lw-migrate` is only compatible with TTS versions 3.12.0 or newer due to breaking API changes.
