### PR TITLE
Disable DevStatusReq MAC command for TTN v2 devices

### DIFF
--- a/pkg/source/ttnv2/source.go
+++ b/pkg/source/ttnv2/source.go
@@ -91,7 +91,10 @@ func (s *Source) ExportDevice(devID string) (*ttnpb.EndDevice, error) {
 	v3dev.LoRaWANPHYVersion = ttnpb.PHY_V1_0_2_REV_B
 	v3dev.FrequencyPlanID = s.config.frequencyPlanID
 
-	v3dev.MACSettings = &ttnpb.MACSettings{}
+	v3dev.MACSettings = &ttnpb.MACSettings{
+		StatusTimePeriodicity:  func(t time.Duration) *time.Duration { return &t }(0),
+		StatusCountPeriodicity: &pbtypes.UInt32Value{Value: 0},
+	}
 	if dev.Uses32BitFCnt {
 		v3dev.MACSettings.Supports32BitFCnt = &pbtypes.BoolValue{
 			Value: dev.Uses32BitFCnt,

--- a/pkg/source/ttnv2/source.go
+++ b/pkg/source/ttnv2/source.go
@@ -190,9 +190,7 @@ func (s *Source) ExportDevice(devID string) (*ttnpb.EndDevice, error) {
 		v3dev.MACState.CurrentParameters.Rx1Delay = ttnpb.RX_DELAY_1
 	}
 	if !deviceSupportsJoin {
-		v3dev.MACSettings = &ttnpb.MACSettings{
-			Rx1Delay: &ttnpb.RxDelayValue{Value: ttnpb.RX_DELAY_1},
-		}
+		v3dev.MACSettings.Rx1Delay = &ttnpb.RxDelayValue{Value: ttnpb.RX_DELAY_1}
 	}
 
 	return v3dev, nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Export TTN v2 devices with `StatusTimePeriodicity` and `StatusTimePeriodicity` set to zero values, so that the `DevStatusReq` commands are disabled after importing to V3.

#### Testing

<!-- How did you verify that this change works? -->

Verify exported devices contain fields, verify fields are set to 0 after importing to TTS.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
