### PR TITLE
Multiple fixes for TTNv2 to work with TTS 3.12

### DIFF
--- a/pkg/source/ttnv2/source.go
+++ b/pkg/source/ttnv2/source.go
@@ -136,8 +136,6 @@ func (s *Source) ExportDevice(devID string) (*ttnpb.EndDevice, error) {
 			SessionKeys: ttnpb.SessionKeys{
 				AppSKey:     &ttnpb.KeyEnvelope{Key: &types.AES128Key{}},
 				FNwkSIntKey: &ttnpb.KeyEnvelope{Key: &types.AES128Key{}},
-				NwkSEncKey:  &ttnpb.KeyEnvelope{Key: &types.AES128Key{}},
-				SNwkSIntKey: &ttnpb.KeyEnvelope{Key: &types.AES128Key{}},
 			},
 			LastFCntUp:    dev.FCntUp,
 			LastNFCntDown: dev.FCntDown,
@@ -153,12 +151,6 @@ func (s *Source) ExportDevice(devID string) (*ttnpb.EndDevice, error) {
 			return nil, err
 		}
 		if err := v3dev.Session.SessionKeys.FNwkSIntKey.Key.Unmarshal(dev.NwkSKey.Bytes()); err != nil {
-			return nil, err
-		}
-		if err := v3dev.Session.SessionKeys.NwkSEncKey.Key.Unmarshal(dev.NwkSKey.Bytes()); err != nil {
-			return nil, err
-		}
-		if err := v3dev.Session.SessionKeys.SNwkSIntKey.Key.Unmarshal(dev.NwkSKey.Bytes()); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/source/ttnv2/source.go
+++ b/pkg/source/ttnv2/source.go
@@ -131,7 +131,7 @@ func (s *Source) ExportDevice(devID string) (*ttnpb.EndDevice, error) {
 		}
 	}
 
-	if s.config.withSession && deviceHasSession {
+	if s.config.withSession && deviceHasSession || !deviceSupportsJoin {
 		v3dev.Session = &ttnpb.Session{
 			SessionKeys: ttnpb.SessionKeys{
 				AppSKey:     &ttnpb.KeyEnvelope{Key: &types.AES128Key{}},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/4042 https://thethingsnetwork.slack.com/archives/C1D8GQMU5/p1618237970077500

#### Changes
<!-- What are the changes made in this pull request? -->

- Always export session for ABP devices (otherwise they cannot be imported to TTS). The imported ABP devices will still not work in TTN v3 due to the DevAddr being in an unsupported block, but not doing this means that breaks the import process (see ref link)
- Generate a MACState for OTAA devices only if there is a session.
- TTS 3.12 no longer accepts NwkSEncKey and SNwkSIntKey for 1.0.2 devices


#### Testing

<!-- How did you verify that this change works? -->

Test locally by exporting devices from TTNv2 and a private V2 instance. Fixes the following scenarios:
- [X] ABP device (would fail because no session keys were set and break the whole import process)
- [X] OTAA device without session (would fail because we tried to import MACState without session keys)
- [X] OTAA device with session (would fail because of NwkSEncKey and SNwkSIntKey).

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The import process is currently because of these bugs.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
