### PR TITLE
Add eui-for-id flag to re-map DeviceID to DevEUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- `--set-eui-as-id` flag to re-map the ID of end devices. Using this flag will set the device ID to the DevEUI (if it has a DevEUI). When combined with the `--dev-id-prefix` flag, the ID will consist of the prefix and the DevEUI.
+
 ### Changed
 
 ### Fixed

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ var (
 			ctx = log.NewContext(context.Background(), logger)
 
 			exportCfg.devIDPrefix, _ = cmd.Flags().GetString("dev-id-prefix")
+			exportCfg.euiForID, _ = cmd.Flags().GetBool("set-eui-as-id")
 
 			rpclog.ReplaceGrpcLogger(logger)
 			return nil
@@ -68,5 +69,6 @@ func init() {
 	rootCmd.PersistentFlags().Bool("verbose", false, "Verbose output")
 	rootCmd.PersistentFlags().Bool("dry-run", false, "Do everything except resetting root and session keys of exported devices")
 	rootCmd.PersistentFlags().String("frequency-plans-url", "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master", "URL for fetching frequency plans")
+	rootCmd.PersistentFlags().Bool("set-eui-as-id", false, "Use the DevEUI as ID")
 	rootCmd.PersistentFlags().String("dev-id-prefix", "", "(optional) value to be prefixed to the resulting device IDs")
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request adds an `--eui-for-id` flag that sets the DeviceID of exported devices to their DevEUI.

Refs [this forum post](https://www.thethingsnetwork.org/forum/t/devids-max-length-before-migration/52200/4?u=htdvisser).

#### Changes
<!-- What are the changes made in this pull request? -->

- Add flag
- Add config
- Add replacement logic
- Add attribute for devices with re-mapped IDs

#### Testing

<!-- How did you verify that this change works? -->

I haven't tested this yet.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
