### PR TITLE
Prevent arguments while migrating TTN v2 applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 # Build files
 /build/
 /dist/
+
+# Local
+main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Argument mismatch for TTNv2 application type.
+
 ### Removed
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ $ export TTNV2_DISCOVERY_SERVER_ADDRESS="discovery.thethings.network:1900"
 
 To export a single device using its Device ID (e.g. `mydevice`):
 
+:warning: Always do a dry run and copy the output as a backup before executing the migration.
+
 ```bash
 # dry run first, verify that no errors occur
 $ ttn-lw-migrate device --source ttnv2 "mydevice" --dry-run --verbose > devices.json

--- a/README.md
+++ b/README.md
@@ -98,10 +98,11 @@ $ ttn-lw-migrate devices --source ttnv2 < device_ids.txt > devices.json
 Similarly, to export all devices of application `my-app-id`:
 
 ```bash
+$ export TTNV2_APP_ID="my-app-id"                     # TTN App ID
 # dry run first, verify that no errors occur
-$ ttn-lw-migrate application --source ttnv2 "my-app-id" --dry-run --verbose > devices.json
+$ ttn-lw-migrate application --source ttnv2 --dry-run --verbose > devices.json
 # export devices
-$ ttn-lw-migrate application --source ttnv2 "my-app-id" > devices.json
+$ ttn-lw-migrate application --source ttnv2 > devices.json
 ```
 
 ## ChirpStack

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -17,7 +17,10 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"go.thethings.network/lorawan-stack-migrate/pkg/source"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 )
+
+var errUnexpectedArguments = errors.DefineInvalidArgument("unexpected_arguments", "no arguments expected for this command")
 
 var (
 	applicationsCmd = &cobra.Command{
@@ -25,6 +28,12 @@ var (
 		Aliases: []string{"applications", "app"},
 		Short:   "Export all devices of an application",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return errUnexpectedArguments.New()
+			}
+			// Add an dummy element so that the iterator runs.
+			// The args are never used since the exporter gets the APP ID from config.
+			args = append(args, "dummy")
 			return exportCommand(cmd, args, func(s source.Source, item string) error {
 				return s.RangeDevices(item, exportCfg.exportDev)
 			})

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -17,10 +17,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"go.thethings.network/lorawan-stack-migrate/pkg/source"
-	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 )
-
-var errUnexpectedArguments = errors.DefineInvalidArgument("unexpected_arguments", "no arguments expected for this command")
 
 var (
 	applicationsCmd = &cobra.Command{
@@ -28,12 +25,6 @@ var (
 		Aliases: []string{"applications", "app"},
 		Short:   "Export all devices of an application",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 0 {
-				return errUnexpectedArguments.New()
-			}
-			// Add an dummy element so that the iterator runs.
-			// The args are never used since the exporter gets the APP ID from config.
-			args = append(args, "dummy")
 			return exportCommand(cmd, args, func(s source.Source, item string) error {
 				return s.RangeDevices(item, exportCfg.exportDev)
 			})

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"io"
-	"os"
 
 	"github.com/spf13/cobra"
 	"go.thethings.network/lorawan-stack-migrate/pkg/source"
@@ -26,7 +25,7 @@ func exportCommand(cmd *cobra.Command, args []string, f func(s source.Source, it
 	var iter Iterator
 	switch len(args) {
 	case 0:
-		iter = NewReaderIterator(os.Stdin, '\n')
+		iter = NewEmptyIterator()
 	default:
 		iter = NewListIterator(args)
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -127,6 +127,12 @@ func (l *listIterator) Next() (string, error) {
 	return "", io.EOF
 }
 
+// NewEmptyIterator returns a new iterator that has only one dummy element.
+// This is valid only for TTNV2 application migration.
+func NewEmptyIterator() Iterator {
+	return &listIterator{items: []string{"dummy"}}
+}
+
 // NewReaderIterator returns a new iterator from a reader.
 func NewReaderIterator(rd io.Reader, sep byte) Iterator {
 	return &readerIterator{rd: bufio.NewReader(rd), sep: sep}

--- a/pkg/source/chirpstack/source.go
+++ b/pkg/source/chirpstack/source.go
@@ -23,6 +23,7 @@ import (
 	csapi "github.com/brocaar/chirpstack-api/go/v3/as/external/api"
 	"github.com/spf13/pflag"
 	"go.thethings.network/lorawan-stack-migrate/pkg/source"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
@@ -42,6 +43,8 @@ function Decoder(bytes, fport) {
 	return Decode(fport, bytes, null);
 }`
 )
+
+var errNoAppID = errors.DefineInvalidArgument("no_app_id", "no Application ID")
 
 // Source implements the Source interface.
 type Source struct {
@@ -90,6 +93,9 @@ func NewSource(ctx context.Context, flags *pflag.FlagSet) (source.Source, error)
 
 // RangeDevices implements the Source interface.
 func (p *Source) RangeDevices(id string, f func(source.Source, string) error) error {
+	if id == "" || id == "dummy" {
+		return errNoAppID.New()
+	}
 	app, err := p.getApplication(id)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #38 

#### Changes
<!-- What are the changes made in this pull request? -->

- This is a classic example of code that's prematurely optimised to the point where it's functionally incorrect.
- For Devices, the user can input a list of args. If there are no args, the tool expects input from stdin; https://github.com/TheThingsNetwork/lorawan-stack-migrate/blob/7f5e86689225c226731426311e83ec2945902222/cmd/export.go#L28-L32
- For Applications,
  -  TTNv2: the args are **ignored** since the `appID` is read from env. So no matter how many args a provided, it only migrates the one single application read from env. This is because the v2 manager client works on single applications.
  - Chirpstack: This requires appID as a list of args.
- I've introduced a "dummy" iterator that replaces the get from stdin. This means that for Devices and Chirpstack, the IDs have to be present in arguments. For TTNv2, the argument can be left out. Invalid args will error in all cases.
- I also added an extra warning for backups.

#### Testing

<!-- How did you verify that this change works? -->

Local tests

##### Case: Empty arg
```
> export TTNV2_APP_ID=kitchen-of-things  
> ./main application --dev-id-prefix mydev --dry-run --source ttnv2

INFO    Clearing device keys    {"dev_eui": "0004A30B00201945", "device_id": "home-node-1"}
{"ids":{"device_id":"mydev-home-node-1","application_ids":{"application_id":"kitchen-of-things"},"dev_eui":"0004A30B00201945","join_eui":"70B3D57ED001CC5C"},"created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","name":"home-node-1","attributes":{"old-id":"home-node-1"},"lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_B","frequency_plan_id":"EU_863_870_TTN","mac_settings":{"rx1_delay":1,"supports_32_bit_f_cnt":true,"status_time_periodicity":"0s","status_count_periodicity":0},"mac_state":{"current_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"desired_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"lorawan_version":"MAC_V1_0_2"},"session":{"dev_addr":"00000000","keys":{"f_nwk_s_int_key":{"key":"00000000000000000000000000000000"},"app_s_key":{"key":"00000000000000000000000000000000"}},"last_f_cnt_up":8,"started_at":"2021-10-28T13:25:44.772807Z"}}
INFO    Clearing device keys    {"dev_eui": "0004A30B001BB199", "device_id": "home-uno-b199"}
{"ids":{"device_id":"mydev-home-uno-b199","application_ids":{"application_id":"kitchen-of-things"},"dev_eui":"0004A30B001BB199","join_eui":"70B3D57ED001CC5C"},"created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","name":"home-uno-b199","attributes":{"old-id":"home-uno-b199"},"lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_B","frequency_plan_id":"EU_863_870_TTN","mac_settings":{"rx1_delay":1,"supports_32_bit_f_cnt":true,"status_time_periodicity":"0s","status_count_periodicity":0},"mac_state":{"current_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"desired_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"lorawan_version":"MAC_V1_0_2"},"session":{"dev_addr":"00000000","keys":{"f_nwk_s_int_key":{"key":"00000000000000000000000000000000"},"app_s_key":{"key":"00000000000000000000000000000000"}},"started_at":"2021-10-28T13:25:44.972772Z"}}
INFO    Clearing device keys    {"dev_eui": "0004A30B001BE5E7", "device_id": "uno-1707"}
{"ids":{"device_id":"mydev-uno-1707","application_ids":{"application_id":"kitchen-of-things"},"dev_eui":"0004A30B001BE5E7","join_eui":"70B3D57ED001CC5C"},"created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","name":"uno-1707","attributes":{"old-id":"uno-1707"},"lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_B","frequency_plan_id":"EU_863_870_TTN","mac_settings":{"rx1_delay":1,"supports_32_bit_f_cnt":true,"status_time_periodicity":"0s","status_count_periodicity":0},"mac_state":{"current_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"desired_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"lorawan_version":"MAC_V1_0_2"},"session":{"dev_addr":"00000000","keys":{"f_nwk_s_int_key":{"key":"00000000000000000000000000000000"},"app_s_key":{"key":"00000000000000000000000000000000"}},"last_f_cnt_up":104,"started_at":"2021-10-28T13:25:45.174321Z"}}
```

##### Case:  Matching argument

```
> export TTNV2_APP_ID=kitchen-of-things  
>  ./main application --dev-id-prefix mydev --dry-run --source ttnv2 "kitchen-of-things"

device keys    {"dev_eui": "0004A30B00201945", "device_id": "home-node-1"}
{"ids":{"device_id":"mydev-home-node-1","application_ids":{"application_id":"kitchen-of-things"},"dev_eui":"0004A30B00201945","join_eui":"70B3D57ED001CC5C"},"created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","name":"home-node-1","attributes":{"old-id":"home-node-1"},"lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_B","frequency_plan_id":"EU_863_870_TTN","mac_settings":{"rx1_delay":1,"supports_32_bit_f_cnt":true,"status_time_periodicity":"0s","status_count_periodicity":0},"mac_state":{"current_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"desired_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"lorawan_version":"MAC_V1_0_2"},"session":{"dev_addr":"00000000","keys":{"f_nwk_s_int_key":{"key":"00000000000000000000000000000000"},"app_s_key":{"key":"00000000000000000000000000000000"}},"last_f_cnt_up":8,"started_at":"2021-10-28T13:24:46.518371Z"}}
INFO    Clearing device keys    {"dev_eui": "0004A30B001BB199", "device_id": "home-uno-b199"}
{"ids":{"device_id":"mydev-home-uno-b199","application_ids":{"application_id":"kitchen-of-things"},"dev_eui":"0004A30B001BB199","join_eui":"70B3D57ED001CC5C"},"created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","name":"home-uno-b199","attributes":{"old-id":"home-uno-b199"},"lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_B","frequency_plan_id":"EU_863_870_TTN","mac_settings":{"rx1_delay":1,"supports_32_bit_f_cnt":true,"status_time_periodicity":"0s","status_count_periodicity":0},"mac_state":{"current_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"desired_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"lorawan_version":"MAC_V1_0_2"},"session":{"dev_addr":"00000000","keys":{"f_nwk_s_int_key":{"key":"00000000000000000000000000000000"},"app_s_key":{"key":"00000000000000000000000000000000"}},"started_at":"2021-10-28T13:24:47.139105Z"}}
INFO    Clearing device keys    {"dev_eui": "0004A30B001BE5E7", "device_id": "uno-1707"}
{"ids":{"device_id":"mydev-uno-1707","application_ids":{"application_id":"kitchen-of-things"},"dev_eui":"0004A30B001BE5E7","join_eui":"70B3D57ED001CC5C"},"created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","name":"uno-1707","attributes":{"old-id":"uno-1707"},"lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_B","frequency_plan_id":"EU_863_870_TTN","mac_settings":{"rx1_delay":1,"supports_32_bit_f_cnt":true,"status_time_periodicity":"0s","status_count_periodicity":0},"mac_state":{"current_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"desired_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"lorawan_version":"MAC_V1_0_2"},"session":{"dev_addr":"00000000","keys":{"f_nwk_s_int_key":{"key":"00000000000000000000000000000000"},"app_s_key":{"key":"00000000000000000000000000000000"}},"last_f_cnt_up":104,"started_at":"2021-10-28T13:24:47.175134Z"}}
```

##### Case: Error mismatched arg

```
> export TTNV2_APP_ID=kitchen-of-things  
> ./main application --dev-id-prefix mydev --dry-run --source ttnv2 "kitchen-of-things-2"  
Error: error:go.thethings.network/lorawan-stack-migrate/pkg/source/ttnv2:wrong_app_id (wrong app ID `kitchen-of-things-2`)
error:go.thethings.network/lorawan-stack-migrate/pkg/source/ttnv2:wrong_app_id (wrong app ID `kitchen-of-things-2`)
    id=kitchen-of-things-2
    correlation_id=3011e1fc05664d4faa4cb79e561e1f5f
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Tested for that as well.


##### Case: Regression for devices

```
> export TTNV2_APP_ID=kitchen-of-things  
> ./main device --dev-id-prefix mydev --dry-run --source ttnv2 "uno-1707" "home-node-1"   

INFO    Clearing device keys    {"dev_eui": "0004A30B001BE5E7", "device_id": "uno-1707"}
{"ids":{"device_id":"mydev-uno-1707","application_ids":{"application_id":"kitchen-of-things"},"dev_eui":"0004A30B001BE5E7","join_eui":"70B3D57ED001CC5C"},"created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","name":"uno-1707","attributes":{"old-id":"uno-1707"},"lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_B","frequency_plan_id":"EU_863_870_TTN","mac_settings":{"rx1_delay":1,"supports_32_bit_f_cnt":true,"status_time_periodicity":"0s","status_count_periodicity":0},"mac_state":{"current_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"desired_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"lorawan_version":"MAC_V1_0_2"},"session":{"dev_addr":"00000000","keys":{"f_nwk_s_int_key":{"key":"00000000000000000000000000000000"},"app_s_key":{"key":"00000000000000000000000000000000"}},"last_f_cnt_up":104,"started_at":"2021-10-28T13:19:38.793381Z"}}
INFO    Clearing device keys    {"dev_eui": "0004A30B00201945", "device_id": "home-node-1"}
{"ids":{"device_id":"mydev-home-node-1","application_ids":{"application_id":"kitchen-of-things"},"dev_eui":"0004A30B00201945","join_eui":"70B3D57ED001CC5C"},"created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","name":"home-node-1","attributes":{"old-id":"home-node-1"},"lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_B","frequency_plan_id":"EU_863_870_TTN","mac_settings":{"rx1_delay":1,"supports_32_bit_f_cnt":true,"status_time_periodicity":"0s","status_count_periodicity":0},"mac_state":{"current_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"desired_parameters":{"max_eirp":16,"adr_nb_trans":1,"rx1_delay":1,"rx2_data_rate_index":3,"rx2_frequency":"869525000","ping_slot_frequency":"869525000","channels":[{"uplink_frequency":"868100000","downlink_frequency":"868100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868300000","downlink_frequency":"868300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"868500000","downlink_frequency":"868500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867100000","downlink_frequency":"867100000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867300000","downlink_frequency":"867300000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867500000","downlink_frequency":"867500000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867700000","downlink_frequency":"867700000","max_data_rate_index":5,"enable_uplink":true},{"uplink_frequency":"867900000","downlink_frequency":"867900000","max_data_rate_index":5,"enable_uplink":true}],"adr_ack_limit_exponent":"ADR_ACK_LIMIT_64","adr_ack_delay_exponent":"ADR_ACK_DELAY_32","ping_slot_data_rate_index_value":3},"lorawan_version":"MAC_V1_0_2"},"session":{"dev_addr":"00000000","keys":{"f_nwk_s_int_key":{"key":"00000000000000000000000000000000"},"app_s_key":{"key":"00000000000000000000000000000000"}},"last_f_cnt_up":8,"started_at":"2021-10-28T13:19:39.430258Z"}}
```


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

⚠️ This removes the option to read IDs from `stdin`. If we need that, then we should have a new flag for that. Either way, this is a breaking config change. The existing configuration is buggy and there's no easy way around it.

This implementation is a bit of a mess. I'd like to rewrite this a bit, but I don't have time for that.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
