### PR TITLE
Fix `app-id` related bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- `app-id` flag/variable is no longer needed when calling `application` command with `ttnv2` and `ttnv3` sources
+- `application` command no longer panics when called with a different `app-id` argument than set with flag/variable
+
 ### Removed
 
 ### Security

--- a/pkg/source/ttnv2/config.go
+++ b/pkg/source/ttnv2/config.go
@@ -117,10 +117,6 @@ func getConfig(flags *pflag.FlagSet) (config, error) {
 	if appAccessKey == "" {
 		return config{}, errNoAppAccessKey.New()
 	}
-	appID := stringFlag("ttnv2.app-id")
-	if appID == "" {
-		return config{}, errNoAppID.New()
-	}
 	frequencyPlanID := stringFlag("ttnv2.frequency-plan-id")
 	if frequencyPlanID == "" {
 		return config{}, errNoFrequencyPlanID.New()
@@ -144,7 +140,7 @@ func getConfig(flags *pflag.FlagSet) (config, error) {
 	return config{
 		sdkConfig: cfg,
 
-		appID:           appID,
+		appID:           stringFlag("ttnv2.app-id"),
 		appAccessKey:    appAccessKey,
 		frequencyPlanID: frequencyPlanID,
 

--- a/pkg/source/ttnv2/source.go
+++ b/pkg/source/ttnv2/source.go
@@ -185,7 +185,9 @@ func (s *Source) ExportDevice(devID string) (*ttnpb.EndDevice, error) {
 }
 
 // RangeDevices implements the source.Source interface.
-func (s *Source) RangeDevices(_ string, f func(source.Source, string) error) error {
+func (s *Source) RangeDevices(appID string, f func(source.Source, string) error) error {
+	s.config.appID = appID
+
 	devices, err := s.mgr.List(0, 0)
 	if err != nil {
 		if err, ok := errors.From(err); ok {

--- a/pkg/source/ttnv2/source.go
+++ b/pkg/source/ttnv2/source.go
@@ -60,6 +60,10 @@ func NewSource(ctx context.Context, flags *pflag.FlagSet) (source.Source, error)
 
 // ExportDevice implements the source.Source interface.
 func (s *Source) ExportDevice(devID string) (*ttnpb.EndDevice, error) {
+	if s.config.appID == "" {
+		return nil, errNoAppID.New()
+	}
+
 	dev, err := s.mgr.Get(devID)
 	if err != nil {
 		if err, ok := errors.From(err); ok {

--- a/pkg/source/ttnv3/config.go
+++ b/pkg/source/ttnv3/config.go
@@ -53,14 +53,9 @@ func getConfig(flags *pflag.FlagSet) (*config, error) {
 		return b
 	}
 
-	appID := stringFlag(flagWithPrefix("app-id"))
-	if appID == "" {
-		return nil, errNoAppID
-	}
-
 	apiKey := stringFlag(flagWithPrefix("app-api-key"))
 	if apiKey == "" {
-		return nil, errNoAppAPIKey
+		return nil, errNoAppAPIKey.New()
 	}
 	api.SetAuth("bearer", apiKey)
 
@@ -88,19 +83,19 @@ func getConfig(flags *pflag.FlagSet) (*config, error) {
 
 	identityServerGRPCAddress := stringFlag(flagWithPrefix("identity-server-grpc-address"))
 	if identityServerGRPCAddress == "" {
-		return nil, errNoIdentityServerGRPCAddress
+		return nil, errNoIdentityServerGRPCAddress.New()
 	}
 	joinServerGRPCAddress := stringFlag(flagWithPrefix("join-server-grpc-address"))
 	if joinServerGRPCAddress == "" {
-		return nil, errNoJoinServerGRPCAddress
+		return nil, errNoJoinServerGRPCAddress.New()
 	}
 	applicationServerGRPCAddress := stringFlag(flagWithPrefix("application-server-grpc-address"))
 	if applicationServerGRPCAddress == "" {
-		return nil, errNoApplicationServerGRPCAddress
+		return nil, errNoApplicationServerGRPCAddress.New()
 	}
 	networkServerGRPCAddress := stringFlag(flagWithPrefix("network-server-grpc-address"))
 	if networkServerGRPCAddress == "" {
-		return nil, errNoNetworkServerGRPCAddress
+		return nil, errNoNetworkServerGRPCAddress.New()
 	}
 	cfg := zap.NewProductionConfig()
 	if boolFlag("verbose") {
@@ -122,7 +117,7 @@ func getConfig(flags *pflag.FlagSet) (*config, error) {
 	noSession := boolFlag(flagWithPrefix("no-session"))
 
 	return &config{
-		appID: appID,
+		appID: stringFlag(flagWithPrefix("app-id")),
 
 		identityServerGRPCAddress:    identityServerGRPCAddress,
 		joinServerGRPCAddress:        joinServerGRPCAddress,

--- a/pkg/source/ttnv3/source.go
+++ b/pkg/source/ttnv3/source.go
@@ -32,6 +32,10 @@ func NewSource(ctx context.Context, flags *pflag.FlagSet) (source.Source, error)
 
 // ExportDevice implements the source.Source interface.
 func (s Source) ExportDevice(devID string) (*ttnpb.EndDevice, error) {
+	if s.config.appID == "" {
+		return nil, errNoAppID.New()
+	}
+
 	isPaths, nsPaths, asPaths, jsPaths := splitEndDeviceGetPaths(ttnpb.BottomLevelFields(ttnpb.EndDeviceFieldPathsNested)...)
 	if len(nsPaths) > 0 {
 		isPaths = ttnpb.AddFields(isPaths, "network_server_address")

--- a/pkg/source/ttnv3/source.go
+++ b/pkg/source/ttnv3/source.go
@@ -101,6 +101,8 @@ func (s Source) ExportDevice(devID string) (*ttnpb.EndDevice, error) {
 
 // RangeDevices implements the source.Source interface.
 func (s Source) RangeDevices(appID string, f func(source.Source, string) error) error {
+	s.config.appID = appID
+
 	is, err := api.Dial(s.ctx, s.config.identityServerGRPCAddress)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #54 

#### Changes
<!-- What are the changes made in this pull request? -->

- Overwrite `app-id` set by flag/variable when calling `application` command
- Check if `app-id` flag/variable is set only when calling `devices` command
- Add `.New()` to errors where it was missing in `ttnv3` source

#### Testing

<!-- How did you verify that this change works? -->

Tested locally

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

n/a

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
