### PR TITLE
Fix `ttnv3` source related bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Added `--ttnv3.no-session` and `--ttnv3.delete-source-device` flags
-
 ### Changed
 
 ### Fixed
 
-- `app-id` flag/variable is no longer needed when calling `application` command with `ttnv2` and `ttnv3` sources
-- `application` command no longer panics when called with a different `app-id` argument than set with flag/variable
+- Using `--ttnv3.no-session` flag will no longer crash.
+- End Device Identifiers are now exported from all available servers.
 
 ### Removed
 
 ### Security
 
-## [v0.9.0] (2022-09-13)
-
-- `ttnv3` source to migrate devices between TTS instances
+## [v0.9.0]
 
 ### Added
+
+- `ttnv3` source to migrate devices between TTS instances.
+- `--ttnv3.no-session` and `--ttnv3.delete-source-device` flags.
+
+### Fixed
+
+- `app-id` flag/variable is no longer needed when calling `application` command with `ttnv2` and `ttnv3` sources.
+- `application` command no longer panics when called with a different `app-id` argument than set with flag/variable.
 
 ## [v0.8.1] (2021-10-12)
 

--- a/pkg/source/ttnv3/errors.go
+++ b/pkg/source/ttnv3/errors.go
@@ -5,6 +5,8 @@ import "go.thethings.network/lorawan-stack/v3/pkg/errors"
 var (
 	errRead = errors.DefinePermissionDenied("read", "failed to read `{file}`")
 
+	errDeviceIdentifiersMismatch = errors.Define("device_identifiers_mismatch", "device identifiers fields {field} do not match with values {a} and {b}")
+
 	errNoAppID                        = errors.DefineInvalidArgument("no_app_id", "no app id")
 	errNoAppAPIKey                    = errors.DefineInvalidArgument("no_app_api_key", "no app api key")
 	errNoIdentityServerGRPCAddress    = errors.DefineInvalidArgument("no_identity_server_grpc_address", "no identity server grpc address")

--- a/pkg/source/ttnv3/source.go
+++ b/pkg/source/ttnv3/source.go
@@ -69,6 +69,9 @@ func (s Source) ExportDevice(devID string) (*ttnpb.EndDevice, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := validateDeviceIds(dev.Ids, res.Ids); err != nil {
+		return nil, err
+	}
 	paths := ttnpb.AddFields(nsPaths, ttnpb.AddFields(asPaths, ttnpb.AddFields(jsPaths, "ids.dev_addr")...)...)
 	if err := dev.SetFields(res, paths...); err != nil {
 		return nil, err
@@ -158,6 +161,9 @@ func (s Source) getEndDevice(ids *ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, 
 			if err != nil {
 				logger.With("error", err).Warn("Could not get end device from Join Server")
 			} else {
+				if err := validateDeviceIds(res.Ids, jsRes.Ids); err != nil {
+					return nil, err
+				}
 				if err := res.SetFields(jsRes, ttnpb.AllowedReachableBottomLevelFields(jsPaths, getEndDeviceFromJS, jsRes.FieldIsZero)...); err != nil {
 					return nil, err
 				}
@@ -178,6 +184,9 @@ func (s Source) getEndDevice(ids *ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, 
 				FieldMask:    ttnpb.FieldMask(asPaths...),
 			})
 			if err != nil {
+				return nil, err
+			}
+			if err := validateDeviceIds(res.Ids, asRes.Ids); err != nil {
 				return nil, err
 			}
 			if err := res.SetFields(asRes, ttnpb.AllowedReachableBottomLevelFields(asPaths, getEndDeviceFromAS, asRes.FieldIsZero)...); err != nil {
@@ -201,6 +210,9 @@ func (s Source) getEndDevice(ids *ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, 
 				},
 			)
 			if err != nil {
+				return nil, err
+			}
+			if err := validateDeviceIds(res.Ids, nsRes.Ids); err != nil {
 				return nil, err
 			}
 			if err := res.SetFields(nsRes, ttnpb.AllowedReachableBottomLevelFields(nsPaths, getEndDeviceFromNS, nsRes.FieldIsZero)...); err != nil {

--- a/pkg/source/ttnv3/util.go
+++ b/pkg/source/ttnv3/util.go
@@ -59,7 +59,6 @@ func clearDeviceSession(dev *ttnpb.EndDevice) error {
 	return dev.SetFields(nil,
 		"activated_at",
 		"mac_state",
-		"last_dev_status_f_cnt_up",
 		"last_dev_status_received_at",
 		"last_seen_at",
 		"pending_mac_state",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Ref https://github.com/TheThingsIndustries/lorawan-stack-support/issues/929

#### Changes
<!-- What are the changes made in this pull request? -->

- Update End Devices `ids` and `{created,updated}_at` fields when getting the device from AS, JS and NS
  - validate that `ids` either match between the devices or are not present


#### Testing

<!-- How did you verify that this change works? -->

Application https://eu1.cloud.thethings.network/console/applications/migrate-without-joineui contains a device registered without the JoinEUI that I attempted to export. The device was exported successfully.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

n/a

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I attached other bugfix commits that otherwise would only be added in https://github.com/TheThingsNetwork/lorawan-stack-migrate/pull/65

Current solution only checks if the fields match and considers empty (`""`) fields matching any other field. This could be left for now or handled in 2 ways:
- first
  - instead of having identifiers `a` and `b` there are `dst` destination and `src` source identifiers
  - `dst` ids overwrite **empty** `src` ids so that the fields that would be overwritten by an empty value won't be overwritten
- second
  - some way of filtering `paths` so that when the `src` value is empty it is removed from the `paths` and then can be removed post-validation

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
