### PR TITLE
Do not validate device address

### DIFF
--- a/pkg/source/tts/util.go
+++ b/pkg/source/tts/util.go
@@ -16,6 +16,7 @@ package tts
 
 import (
 	"bytes"
+	"encoding/hex"
 	"strconv"
 	"strings"
 
@@ -51,7 +52,6 @@ func validateDeviceIds(a, b *ttnpb.EndDeviceIdentifiers) error {
 		{[]byte(a.DeviceId), []byte(b.DeviceId), "device_id"},
 		{a.DevEui, b.DevEui, "dev_eui"},
 		{a.JoinEui, b.JoinEui, "join_eui"},
-		{a.DevAddr, b.DevAddr, "dev_addr"},
 	}
 	if x, y := a.ApplicationIds, b.ApplicationIds; x != nil && y != nil {
 		pairs = append(pairs, pair{[]byte(x.ApplicationId), []byte(y.ApplicationId), "application_ids.application_id"})
@@ -67,7 +67,11 @@ func validateDeviceIds(a, b *ttnpb.EndDeviceIdentifiers) error {
 		if bytes.Equal(s.x, s.y) {
 			continue
 		}
-		return errDeviceIdentifiersMismatch.WithAttributes("field", s.name, "a", s.x, "b", s.y)
+		return errDeviceIdentifiersMismatch.WithAttributes(
+			"field", s.name,
+			"a", hex.EncodeToString(s.x),
+			"b", hex.EncodeToString(s.y),
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR relaxes the validation of the identifier check found in the migration too for the `tts` source.

The reasoning is that different components may have different views over the `ids.dev_addr` field.

1. The Join Server will update the `ids.dev_addr` to the device address provided in the last join, even if the join accept may not reach the device (i.e. the session is not confirmed).
2. The Application Server may be behind with respect to session information, and its own `ids.dev_addr` may be old.

As such, we stop validating the `ids.dev_addr` and instead just use the latest one - the one from the Network Server.

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not validate `ids.dev_addr` between components.


#### Testing

<!-- How did you verify that this change works? -->

Local.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This fixes a regression in itself.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
