### PR TITLE
Export CACs only on explicit request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Each source has its own dedicated command.
+- End Device Claim Authentication Codes are exported only if `--export-cacs` is set.
 
 ### Changed
 
@@ -21,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+
+- Wrong flag name `appplication-server-grpc-address` fixed to `application-server-grpc-address`.
 
 ### Security
 

--- a/pkg/source/tts/config/config.go
+++ b/pkg/source/tts/config/config.go
@@ -98,7 +98,7 @@ func New() (*Config, *pflag.FlagSet) {
 		os.Getenv("TTS_DEFAULT_GRPC_ADDRESS"),
 		"TTS default GRPC Address (optional)")
 	flags.StringVar(&config.ServerConfig.ApplicationServerGRPCAddress,
-		"appplication-server-grpc-address",
+		"application-server-grpc-address",
 		os.Getenv("TTS_APPLICATION_SERVER_GRPC_ADDRESS"),
 		"TTS Application Server GRPC Address")
 	flags.StringVar(&config.ServerConfig.IdentityServerGRPCAddress,
@@ -123,6 +123,12 @@ func New() (*Config, *pflag.FlagSet) {
 		false,
 		"TTS delete exported devices")
 
+	flags.BoolVar(&config.ExportCACs,
+		"export-cacs",
+		false,
+		"Export Claim Authentication Codes (CAC)",
+	)
+
 	return config, flags
 }
 
@@ -131,11 +137,14 @@ type Config struct {
 
 	ServerConfig *serverConfig
 
-	caPath, appAPIKey,
-	AppID string
+	insecure  bool
+	caPath    string
+	appAPIKey string
 
-	insecure, NoSession,
+	ExportCACs         bool
+	NoSession          bool
 	DeleteSourceDevice bool
+	AppID              string
 }
 
 func (c *Config) Initialize(rootConfig source.Config) error {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Export CACs only on explicit request. 

#### Changes
<!-- What are the changes made in this pull request? -->

- Export CACs only if the `export-cacs` flag is set. This is to allow users of older TTS versions to export CACs to register them separately in TTJS.

#### Testing

<!-- How did you verify that this change works? -->

Local

```
Export devices by Device ID

Usage:
  ttn-lw-migrate tts device ... [flags]

Aliases:
  device, end-devices, end-device, devices, devs, dev, d

Flags:
      --app-api-key string                       TTS Application Access Key (with 'devices' permissions) (default "NNSXS.ISRMVNVKICT3SF5U5YUYOLX4CRLKHMAEOGIY55I.KAD3BCKHBLPG5CHXJJHKBAWC7LIAY6ZWJUVR7VCV6Z557WFKQVKA")
      --app-id string                            TTS Application ID (default "test-app")
      --application-server-grpc-address string   TTS Application Server GRPC Address (default "localhost:1884")
      --ca-file string                           TTS Path to a CA file (optional)
      --default-grpc-address string              TTS default GRPC Address (optional)
      --delete-source-device                     TTS delete exported devices
      --export-cacs                              Export Claim Authentication Codes (CAC)
  -h, --help                                     help for device
      --identity-server-grpc-address string      TTS Identity Server GRPC Address (default "localhost:1884")
      --insecure                                 TTS allow TCP connection
      --join-server-grpc-address string          TTS Join Server GRPC Address (default "localhost:1884")
      --network-server-grpc-address string       TTS Network Server GRPC Address (default "localhost:1884")
      --no-session                               TTS export devices without session

Global Flags:
      --dry-run                      Do everything except resetting root and session keys of exported devices
      --frequency-plans-url string   URL for fetching frequency plans (default "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master")
      --verbose                      Verbose output
-----------------------------------------------------

 ./ttn-lw-migrate tts device eui-1234234324532454 --dry-run --insecure
{"level":"warn","ts":1688551220.134939,"caller":"config/config.go:167","msg":"Using insecure connection to API"}
{"ids":{"device_id":"eui-1234234324532454","application_ids":{"application_id":"test-app"},"dev_eui":"1234234324532454","join_eui":"2121432434354345"},"created_at":"2023-07-05T09:42:31.452333Z","updated_at":"2023-07-05T09:42:31.452333Z","version_ids":{"brand_id":"abeeway", "model_id":"abeeway-compact-tracker", "hardware_version":"1.0", "firmware_version":"2.1", "band_id":"EU_863_870"},"lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_B","frequency_plan_id":"EU_863_870_TTN","supports_join":true,"root_keys":{"app_key":{"key":"227D012D60757387B893EBA76A28323D"}},"mac_settings":{"supports_32_bit_f_cnt":true},"lora_alliance_profile_ids":{}}


 ./ttn-lw-migrate tts device eui-1234234324532454 --export-cacs --dry-run --insecure
{"level":"warn","ts":1688551208.2782679,"caller":"config/config.go:167","msg":"Using insecure connection to API"}
{"ids":{"device_id":"eui-1234234324532454","application_ids":{"application_id":"test-app"},"dev_eui":"1234234324532454","join_eui":"2121432434354345"},"created_at":"2023-07-05T09:42:31.452333Z","updated_at":"2023-07-05T09:42:31.452333Z","version_ids":{"brand_id":"abeeway", "model_id":"abeeway-compact-tracker", "hardware_version":"1.0", "firmware_version":"2.1", "band_id":"EU_863_870"},"lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_B","frequency_plan_id":"EU_863_870_TTN","supports_join":true,"root_keys":{"app_key":{"key":"227D012D60757387B893EBA76A28323D"}},"mac_settings":{"supports_32_bit_f_cnt":true},"claim_authentication_code":{"value":"123456"},"lora_alliance_profile_ids":{}}
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Regular export also tested.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

There's one small bug fix with a command line flag.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
