### PR TITLE
Erase device address on no session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Wrong flag name `appplication-server-grpc-address` fixed to `application-server-grpc-address`.
+- `--ttnv3.no-session` no longer keeps the end device device address.
 
 ### Security
 

--- a/pkg/source/tts/util.go
+++ b/pkg/source/tts/util.go
@@ -110,9 +110,10 @@ func updateDeviceTimestamps(dev, src *ttnpb.EndDevice) {
 func clearDeviceSession(dev *ttnpb.EndDevice) error {
 	return dev.SetFields(nil,
 		"activated_at",
-		"mac_state",
+		"ids.dev_addr",
 		"last_dev_status_received_at",
 		"last_seen_at",
+		"mac_state",
 		"pending_mac_state",
 		"pending_session",
 		"session",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/952

#### Changes
<!-- What are the changes made in this pull request? -->

- Erase the device address when `no-session` is used.


#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This fixes a bug in itself, which is that the device address persists even though the session does not. Both the AS and the JS reject the resulting end device.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
