### PR TITLE
Fix source initialization order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Source command line parameters not being visible.
+
 ### Security
 
 ## [v0.9.0] (2023-10-18)

--- a/cmd/chirpstack/chirpstack.go
+++ b/cmd/chirpstack/chirpstack.go
@@ -14,7 +14,10 @@
 
 package chirpstack
 
-import "go.thethings.network/lorawan-stack-migrate/pkg/commands"
+import (
+	"go.thethings.network/lorawan-stack-migrate/pkg/commands"
+	_ "go.thethings.network/lorawan-stack-migrate/pkg/source/chirpstack"
+)
 
 const sourceName = "chirpstack"
 

--- a/cmd/ttn-lw-migrate/main.go
+++ b/cmd/ttn-lw-migrate/main.go
@@ -17,10 +17,6 @@ package main
 import (
 	"os"
 
-	_ "go.thethings.network/lorawan-stack-migrate/pkg/source/chirpstack" // ChirpStack source
-	_ "go.thethings.network/lorawan-stack-migrate/pkg/source/ttnv2"      // TTNv2 source
-	_ "go.thethings.network/lorawan-stack-migrate/pkg/source/tts"        // TTS source
-
 	"go.thethings.network/lorawan-stack-migrate/cmd"
 )
 

--- a/cmd/ttnv2/ttnv2.go
+++ b/cmd/ttnv2/ttnv2.go
@@ -14,7 +14,10 @@
 
 package ttnv2
 
-import "go.thethings.network/lorawan-stack-migrate/pkg/commands"
+import (
+	"go.thethings.network/lorawan-stack-migrate/pkg/commands"
+	_ "go.thethings.network/lorawan-stack-migrate/pkg/source/ttnv2"
+)
 
 const sourceName = "ttnv2"
 

--- a/cmd/tts/tts.go
+++ b/cmd/tts/tts.go
@@ -14,7 +14,10 @@
 
 package tts
 
-import "go.thethings.network/lorawan-stack-migrate/pkg/commands"
+import (
+	"go.thethings.network/lorawan-stack-migrate/pkg/commands"
+	_ "go.thethings.network/lorawan-stack-migrate/pkg/source/tts"
+)
 
 const sourceName = "tts"
 

--- a/pkg/commands/source.go
+++ b/pkg/commands/source.go
@@ -53,7 +53,10 @@ func WithDevicesOptions(opts ...Option) SourceOptions {
 
 // Source returns a new source command.
 func Source(sourceName, short string, opts ...SourceOptions) *cobra.Command {
-	fs, _ := source.FlagSet(sourceName)
+	fs, err := source.FlagSet(sourceName)
+	if err != nil {
+		panic(err)
+	}
 
 	sourceOpts := new(SourceOptions)
 	for _, opt := range opts {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the fact that source commands are created _after_ the sources are registered. This causes the flag set of the source to be empty.

Before:

```
go run ./cmd/ttn-lw-migrate chirpstack devices --help
Export devices by DevEUI

Usage:
  ttn-lw-migrate chirpstack device ... [flags]

Aliases:
  device, end-devices, end-device, devices, devs, dev, d

Flags:
  -h, --help   help for device

Global Flags:
      --dry-run                      Do everything except resetting root and session keys of exported devices
      --frequency-plans-url string   URL for fetching frequency plans (default "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master")
      --verbose                      Verbose output
```

After:

```
go run ./cmd/ttn-lw-migrate chirpstack devices --help
Export devices by DevEUI

Usage:
  ttn-lw-migrate chirpstack device ... [flags]

Aliases:
  device, end-devices, end-device, devices, devs, dev, d

Flags:
      --api-ca string              (optional) CA for TLS
      --api-insecure               Do not connect to ChirpStack over TLS
      --api-token string           ChirpStack API Token
      --api-url string             ChirpStack API URL
      --export-session             Export device session keys from ChirpStack (default true)
      --export-vars                Export device variables from ChirpStack
      --frequency-plan-id string   Frequency Plan ID of exported devices
  -h, --help                       help for device
      --join-eui string            JoinEUI of exported devices

Global Flags:
      --dry-run                      Do everything except resetting root and session keys of exported devices
      --frequency-plans-url string   URL for fetching frequency plans (default "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master")
      --verbose                      Verbose output
```

#### Changes
<!-- What are the changes made in this pull request? -->

- Register the sources next to the source commands.


#### Testing

<!-- How did you verify that this change works? -->

Local testing - see above.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This fixes a regression.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer please take a look.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
