### PR TITLE
Fix errors and panics in the chirpstack v3 source 

### DIFF
--- a/pkg/source/chirpstack/source.go
+++ b/pkg/source/chirpstack/source.go
@@ -30,7 +30,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -52,8 +51,7 @@ function Decoder(bytes, fport) {
 type Source struct {
 	*config.Config
 
-	ctx        context.Context
-	ClientConn *grpc.ClientConn
+	ctx context.Context
 
 	applications map[int64]*csapi.Application
 	devProfiles  map[string]*csapi.DeviceProfile


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix errors and panics in the chirpstack v3 source. Ref: https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1029

#### Changes
<!-- What are the changes made in this pull request? -->

- Pull Custom CA file only if CA path is set and `insecure` is not set.
- Replace the deprecated `grpc.WithInsecure()` method.
- Remove the `ClientConn` field on the `Source` so that the underlying one from the `Config` may be used.
 
#### Testing

<!-- How did you verify that this change works? -->

Local with a ChirpStack v4 instance. This of course doesn't check actual migration but makes sure that the tool doesn't panic.

This will be tested by CE as a part of https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1029.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

NA. This is fixing existing bugs.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
