### PR TITLE
Fix update of flags from the environment 

### DIFF
--- a/pkg/source/chirpstack/config/config.go
+++ b/pkg/source/chirpstack/config/config.go
@@ -94,26 +94,47 @@ func New() *Config {
 func (c *Config) Initialize(src source.Config) error {
 	c.src = src
 
-	if c.apiKey = os.Getenv("CHIRPSTACK_API_KEY"); c.apiKey == "" {
+	if apiKey := os.Getenv("CHIRPSTACK_API_KEY"); apiKey != "" {
+		c.apiKey = apiKey
+	}
+	if url := os.Getenv("CHIRPSTACK_API_URL"); url != "" {
+		c.url = url
+	}
+	if caCertPath := os.Getenv("CHIRPSTACK_CA_CERT_PATH"); caCertPath != "" {
+		c.caCertPath = caCertPath
+	}
+	if insecure := os.Getenv("CHIRPSTACK_INSECURE"); insecure != "" {
+		c.insecure = insecure == "true"
+	}
+	if exportVars := os.Getenv("EXPORT_VARS"); exportVars != "" {
+		c.ExportVars = exportVars == "true"
+	}
+	if exportSession := os.Getenv("EXPORT_SESSION"); exportSession != "" {
+		c.ExportSession = exportSession == "true"
+	}
+	if joinEUI := os.Getenv("JOIN_EUI"); joinEUI != "" {
+		c.joinEUI = joinEUI
+	}
+	if frequencyPlanID := os.Getenv("FREQUENCY_PLAN_ID"); frequencyPlanID != "" {
+		c.FrequencyPlanID = frequencyPlanID
+	}
+
+	if c.apiKey == "" {
 		return errNoAPIToken.New()
 	}
-	if c.url = os.Getenv("CHIRPSTACK_API_URL"); c.url == "" {
+	if c.url == "" {
 		return errNoAPIURL.New()
 	}
-	if c.FrequencyPlanID = os.Getenv("FREQUENCY_PLAN_ID"); c.FrequencyPlanID == "" {
+	if c.FrequencyPlanID == "" {
 		return errNoFrequencyPlan.New()
 	}
-	if c.joinEUI = os.Getenv("JOIN_EUI"); c.joinEUI == "" {
+	if c.joinEUI == "" {
 		return errNoJoinEUI.New()
 	}
 	c.JoinEUI = &types.EUI64{}
 	if err := c.JoinEUI.UnmarshalText([]byte(c.joinEUI)); err != nil {
 		return errInvalidJoinEUI.WithAttributes("join_eui", c.joinEUI)
 	}
-	c.caCertPath = os.Getenv("CHIRPSTACK_CA_CERT_PATH")
-	c.insecure = os.Getenv("CHIRPSTACK_INSECURE") == "true"
-	c.ExportSession = os.Getenv("EXPORT_SESSION") == "true"
-	c.ExportVars = os.Getenv("EXPORT_VARS") == "true"
 
 	err := c.dialGRPC(
 		grpc.FailOnNonTempDialError(true),

--- a/pkg/source/firefly/config.go
+++ b/pkg/source/firefly/config.go
@@ -104,34 +104,55 @@ where the devices are exported but they are still valid on the firefly server
 func (c *Config) Initialize(src source.Config) error {
 	c.src = src
 
-	if c.appID = os.Getenv("APP_ID"); c.appID == "" {
-		return errNoAppID.New()
+	if appID := os.Getenv("APP_ID"); appID == "" {
+		c.appID = appID
 	}
-	if c.frequencyPlanID = os.Getenv("FREQUENCY_PLAN_ID"); c.frequencyPlanID == "" {
-		return errNoFrequencyPlanID.New()
+	if frequencyPlanID := os.Getenv("FREQUENCY_PLAN_ID"); frequencyPlanID == "" {
+		c.frequencyPlanID = frequencyPlanID
 	}
-	if c.joinEUI = os.Getenv("JOIN_EUI"); c.joinEUI == "" {
-		return errNoJoinEUI.New()
+	if joinEUI := os.Getenv("JOIN_EUI"); joinEUI == "" {
+		c.joinEUI = joinEUI
 	}
-	if invalidateKeys := os.Getenv("JOIN_EUI"); invalidateKeys == "true" {
+	if invalidateKeys := os.Getenv("INVALIDATE_KEYS"); invalidateKeys == "true" {
 		c.invalidateKeys = true
 	}
 	if all := os.Getenv("ALL"); all == "true" {
 		c.all = true
 	}
 
-	if c.Host = os.Getenv("FIREFLY_HOST"); c.Host == "" {
-		return errNoHost.New()
+	if host := os.Getenv("FIREFLY_HOST"); host == "" {
+		c.Host = host
 	}
-	if c.APIKey = os.Getenv("FIREFLY_API_KEY"); c.APIKey == "" {
-		return errNoAPIKey.New()
+	if apiKey := os.Getenv("FIREFLY_API_KEY"); apiKey == "" {
+		c.APIKey = apiKey
 	}
-	c.CACertPath = os.Getenv("FIREFLY_CA_CERT_PATH")
+	if caCertPath := os.Getenv("FIREFLY_CA_CERT_PATH"); caCertPath == "" {
+		c.CACertPath = caCertPath
+	}
 	if useHTTP := os.Getenv("FIREFLY_USE_HTTP"); useHTTP == "true" {
 		c.UseHTTP = true
 	}
+	if macVersion := os.Getenv("MAC_VERSION"); macVersion == "" {
+		c.macVersion = macVersion
+	}
 
-	c.macVersion = os.Getenv("MAC_VERSION")
+	if c.appID == "" {
+		return errNoAppID.New()
+	}
+	if c.frequencyPlanID == "" {
+		return errNoFrequencyPlanID.New()
+	}
+	if c.joinEUI == "" {
+		return errNoJoinEUI.New()
+	}
+
+	if c.Host == "" {
+		return errNoHost.New()
+	}
+	if c.APIKey == "" {
+		return errNoAPIKey.New()
+	}
+
 	switch c.macVersion {
 	case "1.0.0":
 		c.derivedMacVersion = ttnpb.MACVersion_MAC_V1_0

--- a/pkg/source/tts/config/config.go
+++ b/pkg/source/tts/config/config.go
@@ -66,61 +66,61 @@ func (c *serverConfig) applyDefaults() {
 	)
 }
 
-func New() (*Config, *pflag.FlagSet) {
-	var (
-		config = &Config{ServerConfig: &serverConfig{}}
-		flags  = &pflag.FlagSet{}
-	)
+func New() *Config {
+	config := &Config{
+		ServerConfig: &serverConfig{},
+		flags:        &pflag.FlagSet{},
+	}
 
-	flags.StringVar(&config.AppID,
+	config.flags.StringVar(&config.AppID,
 		"app-id",
-		os.Getenv("TTS_APP_ID"),
+		"",
 		"TTS Application ID")
-	flags.StringVar(&config.appAPIKey,
+	config.flags.StringVar(&config.appAPIKey,
 		"app-api-key",
-		os.Getenv("TTS_APP_API_KEY"),
+		"",
 		"TTS Application Access Key (with 'devices' permissions)")
 
-	flags.StringVar(&config.caPath,
+	config.flags.StringVar(&config.caPath,
 		"ca-file",
-		os.Getenv("TTS_CA_FILE"),
+		"",
 		"TTS Path to a CA file (optional)")
-	flags.BoolVar(&config.insecure,
+	config.flags.BoolVar(&config.insecure,
 		"insecure",
 		false,
 		"TTS allow TCP connection")
 
-	flags.StringVar(&config.ServerConfig.defaultGRPCAddress,
+	config.flags.StringVar(&config.ServerConfig.defaultGRPCAddress,
 		"default-grpc-address",
-		os.Getenv("TTS_DEFAULT_GRPC_ADDRESS"),
+		"",
 		"TTS default GRPC Address (optional)")
-	flags.StringVar(&config.ServerConfig.ApplicationServerGRPCAddress,
+	config.flags.StringVar(&config.ServerConfig.ApplicationServerGRPCAddress,
 		"application-server-grpc-address",
-		os.Getenv("TTS_APPLICATION_SERVER_GRPC_ADDRESS"),
+		"",
 		"TTS Application Server GRPC Address")
-	flags.StringVar(&config.ServerConfig.IdentityServerGRPCAddress,
+	config.flags.StringVar(&config.ServerConfig.IdentityServerGRPCAddress,
 		"identity-server-grpc-address",
-		os.Getenv("TTS_IDENTITY_SERVER_GRPC_ADDRESS"),
+		"",
 		"TTS Identity Server GRPC Address")
-	flags.StringVar(&config.ServerConfig.JoinServerGRPCAddress,
+	config.flags.StringVar(&config.ServerConfig.JoinServerGRPCAddress,
 		"join-server-grpc-address",
-		os.Getenv("TTS_JOIN_SERVER_GRPC_ADDRESS"),
+		"",
 		"TTS Join Server GRPC Address")
-	flags.StringVar(&config.ServerConfig.NetworkServerGRPCAddress,
+	config.flags.StringVar(&config.ServerConfig.NetworkServerGRPCAddress,
 		"network-server-grpc-address",
-		os.Getenv("TTS_NETWORK_SERVER_GRPC_ADDRESS"),
+		"",
 		"TTS Network Server GRPC Address")
 
-	flags.BoolVar(&config.NoSession,
+	config.flags.BoolVar(&config.NoSession,
 		"no-session",
 		false,
 		"TTS export devices without session")
-	flags.BoolVar(&config.DeleteSourceDevice,
+	config.flags.BoolVar(&config.DeleteSourceDevice,
 		"delete-source-device",
 		false,
 		"TTS delete exported devices")
 
-	return config, flags
+	return config
 }
 
 type Config struct {
@@ -135,10 +135,50 @@ type Config struct {
 	NoSession          bool
 	DeleteSourceDevice bool
 	AppID              string
+
+	flags *pflag.FlagSet
 }
 
 func (c *Config) Initialize(rootConfig source.Config) error {
 	c.Config = rootConfig
+
+	if appID := os.Getenv("TTS_APP_ID"); appID != "" {
+		c.AppID = appID
+	}
+	if appAPIKey := os.Getenv("TTS_APP_API_KEY"); appAPIKey != "" {
+		c.appAPIKey = appAPIKey
+	}
+	if caPath := os.Getenv("TTS_CA_FILE"); caPath != "" {
+		c.caPath = caPath
+	}
+	if insecure := os.Getenv("TTS_INSECURE"); insecure == "true" {
+		c.insecure = true
+	}
+	if noSession := os.Getenv("TTS_NO_SESSION"); noSession == "true" {
+		c.NoSession = true
+	}
+	if deleteSourceDevice := os.Getenv("TTS_DELETE_SOURCE_DEVICE"); deleteSourceDevice == "true" {
+		c.DeleteSourceDevice = true
+	}
+	if defaultGRPCAddress := os.Getenv("TTS_DEFAULT_GRPC_ADDRESS"); defaultGRPCAddress != "" {
+		c.ServerConfig.defaultGRPCAddress = defaultGRPCAddress
+	}
+	if applicationServerGRPCAddress := os.Getenv("TTS_APPLICATION_SERVER_GRPC_ADDRESS"); applicationServerGRPCAddress != "" {
+		c.ServerConfig.ApplicationServerGRPCAddress = applicationServerGRPCAddress
+	}
+	if identityServerGRPCAddress := os.Getenv("TTS_IDENTITY_SERVER_GRPC_ADDRESS"); identityServerGRPCAddress != "" {
+		c.ServerConfig.IdentityServerGRPCAddress = identityServerGRPCAddress
+	}
+	if joinServerGRPCAddress := os.Getenv("TTS_JOIN_SERVER_GRPC_ADDRESS"); joinServerGRPCAddress != "" {
+		c.ServerConfig.JoinServerGRPCAddress = joinServerGRPCAddress
+	}
+	if networkServerGRPCAddress := os.Getenv("TTS_NETWORK_SERVER_GRPC_ADDRESS"); networkServerGRPCAddress != "" {
+		c.ServerConfig.NetworkServerGRPCAddress = networkServerGRPCAddress
+	}
+
+	if c.AppID == "" {
+		return errNoAppID.New()
+	}
 
 	if c.appAPIKey == "" {
 		return errNoAppAPIKey.New()
@@ -192,4 +232,9 @@ func setCustomCA(path string) error {
 		return err
 	}
 	return nil
+}
+
+// Flags returns the flags for the configuration.
+func (c *Config) Flags() *pflag.FlagSet {
+	return c.flags
 }

--- a/pkg/source/tts/config/errors.go
+++ b/pkg/source/tts/config/errors.go
@@ -17,6 +17,7 @@ package config
 import "go.thethings.network/lorawan-stack/v3/pkg/errors"
 
 var (
+	errNoAppID                        = errors.DefineInvalidArgument("no_app_id", "no app id")
 	errNoAppAPIKey                    = errors.DefineInvalidArgument("no_app_api_key", "no app api key")
 	errNoIdentityServerGRPCAddress    = errors.DefineInvalidArgument("no_identity_server_grpc_address", "no identity server grpc address")
 	errNoJoinServerGRPCAddress        = errors.DefineInvalidArgument("no_join_server_grpc_address", "no join server grpc address")

--- a/pkg/source/tts/source.go
+++ b/pkg/source/tts/source.go
@@ -34,10 +34,13 @@ type Source struct {
 
 func createNewSource(cfg *config.Config) source.CreateSource {
 	return func(ctx context.Context, rootCfg source.Config) (source.Source, error) {
+		if err := cfg.Initialize(rootCfg); err != nil {
+			return nil, err
+		}
 		return Source{
 			ctx:    ctx,
 			config: cfg,
-		}, cfg.Initialize(rootCfg)
+		}, nil
 	}
 }
 

--- a/pkg/source/tts/tts.go
+++ b/pkg/source/tts/tts.go
@@ -20,12 +20,12 @@ import (
 )
 
 func init() {
-	cfg, flags := config.New()
+	cfg := config.New()
 
 	source.RegisterSource(source.Registration{
 		Name:        "tts",
 		Description: "Migrate from The Things Stack",
-		FlagSet:     flags,
+		FlagSet:     cfg.Flags(),
 		Create:      createNewSource(cfg),
 	})
 }

--- a/pkg/source/wanesy/config.go
+++ b/pkg/source/wanesy/config.go
@@ -72,13 +72,22 @@ func NewConfig() *Config {
 func (c *Config) Initialize(src source.Config) error {
 	c.src = src
 
-	if c.appID = os.Getenv("APP_ID"); c.appID == "" {
+	if appID := os.Getenv("APP_ID"); appID != "" {
+		c.appID = appID
+	}
+	if frequencyPlanID := os.Getenv("FREQUENCY_PLAN_ID"); frequencyPlanID != "" {
+		c.frequencyPlanID = frequencyPlanID
+	}
+	if csvPath := os.Getenv("CSV_PATH"); csvPath != "" {
+		c.csvPath = csvPath
+	}
+	if c.appID == "" {
 		return errNoAppID.New()
 	}
-	if c.frequencyPlanID = os.Getenv("FREQUENCY_PLAN_ID"); c.frequencyPlanID == "" {
+	if c.frequencyPlanID == "" {
 		return errNoFrequencyPlanID.New()
 	}
-	if c.csvPath = os.Getenv("CSV_PATH"); c.csvPath == "" {
+	if c.csvPath == "" {
 		return errNoCSVFileProvided.New()
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refs https://github.com/TheThingsNetwork/lorawan-stack-migrate/pull/112#discussion_r1519974219

#### Changes
<!-- What are the changes made in this pull request? -->

- For the ChirpStack, Wanesy and Firefly sources, make sure that env is used only when set.
- Refactor the `tts` config to match other sources and don't print defaults to the env.


#### Testing

<!-- How did you verify that this change works? -->

##### TTS

Check that secrets are not printed.
```
./main tts device --help
Export devices by Device ID

Usage:
  ttn-lw-migrate tts device ... [flags]

Aliases:
  device, end-devices, end-device, devices, devs, dev, d

Flags:
      --app-api-key string                       TTS Application Access Key (with 'devices' permissions)
      --app-id string                            TTS Application ID
      --application-server-grpc-address string   TTS Application Server GRPC Address
      --ca-file string                           TTS Path to a CA file (optional)
      --default-grpc-address string              TTS default GRPC Address (optional)
      --delete-source-device                     TTS delete exported devices
  -h, --help                                     help for device
      --identity-server-grpc-address string      TTS Identity Server GRPC Address
      --insecure                                 TTS allow TCP connection
      --join-server-grpc-address string          TTS Join Server GRPC Address
      --network-server-grpc-address string       TTS Network Server GRPC Address
      --no-session                               TTS export devices without session

Global Flags:
      --dev-id-prefix string         (optional) value to be prefixed to the resulting device IDs
      --dry-run                      Do everything except resetting root and session keys of exported devices
      --frequency-plans-url string   URL for fetching frequency plans (default "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master")
      --verbose                      Verbose output
```

##### Others

Check that env is only used when set.
```
./main chirpstack device 0004a30b001bc8a7 --dry-run --api-key test --api-url localhost:8081
Error: connection error: desc = "transport: error while dialing: dial tcp 127.0.0.1:8081: connect: connection refused"
connection error: desc = "transport: error while dialing: dial tcp 127.0.0.1:8081: connect: connection refused"
    correlation_id=0fad85a72890410c82abb6964662db80

export CHIRPSTACK_API_URL="localhost:8080"

./main chirpstack device 0004a30b001bc8a7 --dry-run --api-key test --api-url localhost:8081
Error: connection error: desc = "transport: error while dialing: dial tcp 127.0.0.1:8080: connect: connection refused"
connection error: desc = "transport: error while dialing: dial tcp 127.0.0.1:8080: connect: connection refused"
    correlation_id=0fad85a72890410c82abb6964662db80
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Tested export using the `tts` source.

```
./main tts device 'test-device-ade' --dry-run
{"ids":{"device_id":"test-device-ade","application_ids":{"application_id":"sec"},"dev_eui":"70B3D57ED8002A47","join_eui":"AFBAD1928EEE2938"},"created_at":"2024-03-13T10:46:57.421090786Z","updated_at":"2024-03-13T10:46:57.421090786Z","version_ids":{"brand_id":"adeunis","model_id":"analog","hardware_version":"1.04","firmware_version":"1.03","band_id":"EU_863_870"},"lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_A","frequency_plan_id":"EU_863_870_TTN","supports_join":true,"root_keys":{"app_key":{"key":"8B9C4D0EE0AF31371BBDEFAAA14F2A63"}},"mac_settings":{"supports_32_bit_f_cnt":true},"formatters":{"up_formatter":"FORMATTER_REPOSITORY","down_formatter":"FORMATTER_REPOSITORY"}}
```


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
