### PR TITLE
Strip dev_addr from ids in TTS exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # macOS related
 *.DS_store
+
+# Go
+**/vendor/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Strip ids.dev_addr from exported devices
+
 ## [v0.12.0] (2024-03-13)
 
 ### Added
@@ -145,6 +147,3 @@ NOTE: These links should respect backports. See https://github.com/TheThingsNetw
 -->
 
 [unreleased]: https://github.com/TheThingsNetwork/lorawan-stack-migrate/v0.7.0...master
-[0.7.0]: https://github.com/TheThingsNetwork/lorawan-stack-migrate/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/TheThingsNetwork/lorawan-stack-migrate/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/TheThingsNetwork/lorawan-stack-migrate/compare/v0.4.0...v0.5.0

--- a/pkg/source/tts/source.go
+++ b/pkg/source/tts/source.go
@@ -73,9 +73,14 @@ func (s Source) ExportDevice(devID string) (*ttnpb.EndDevice, error) {
 	if err := validateDeviceIds(dev.Ids, res.Ids); err != nil {
 		return nil, err
 	}
-	paths := ttnpb.AddFields(nsPaths, ttnpb.AddFields(asPaths, ttnpb.AddFields(jsPaths, "ids.dev_addr")...)...)
+	paths := ttnpb.AddFields(nsPaths, ttnpb.AddFields(asPaths, jsPaths...)...)
 	if err := dev.SetFields(res, paths...); err != nil {
 		return nil, err
+	}
+	// Clear ids.dev_addr (denormalized session state) so the export can be
+	// re-imported via the CLI; session.dev_addr remains the source of truth.
+	if dev.Ids != nil {
+		dev.Ids.DevAddr = nil
 	}
 	// Clear all "{server}_address" fields from exported device
 	if err := dev.SetFields(nil, "application_server_address", "join_server_address", "network_server_address"); err != nil {

--- a/pkg/source/tts/source.go
+++ b/pkg/source/tts/source.go
@@ -113,7 +113,10 @@ func (s Source) ExportDevice(devID string) (*ttnpb.EndDevice, error) {
 }
 
 // Iterator implements source.Source.
-func (s Source) Iterator(bool) iterator.Iterator {
+func (s Source) Iterator(isApplication bool) iterator.Iterator {
+	if isApplication && s.config.AppID != "" {
+		return iterator.NewListIterator([]string{s.config.AppID})
+	}
 	return iterator.NewReaderIterator(os.Stdin, '\n')
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1444#issuecomment-4342738364

#### Changes
<!-- What are the changes made in this pull request? -->

- Strip dev_addr from ids on export for TTS source
- Fix the iterator for application mode for TTS source
- Add vendor directory to .gitignore

#### Testing

Before:

```
-> % go run ./cmd/ttn-lw-migrate --dry-run tts device --app-api-key $API_KEY --app-id adrian-test-lab --default-grpc-address tti.staging1.cloud.thethings.industries:8884 < devices.txt | jq '.ids'
{
  "device_id": "eui-0004a310001ab188",
  "application_ids": {
    "application_id": "adrian-test-lab"
  },
  "dev_eui": "0004A310001AB188",
  "join_eui": "70B3D57ED0000000",
  "dev_addr": "26002C07"
}
```

After:

```
-> % go run ./cmd/ttn-lw-migrate --dry-run tts device --app-api-key $API_KEY --app-id adrian-test-lab --default-grpc-address tti.staging1.cloud.thethings.industries:8884 < devices.txt | jq '.ids'
{
  "device_id": "eui-0004a310001ab188",
  "application_ids": {
    "application_id": "adrian-test-lab"
  },
  "dev_eui": "0004A310001AB188",
  "join_eui": "70B3D57ED0000000"
}
```


##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
